### PR TITLE
List split

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -332,7 +332,7 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
             }
         }
     }
-
+    
     assert!(frame_stack.is_empty());
     assert_eq!(frame.instr_pointer, 0);
     assert_eq!(value_stack.len(), 1);

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -132,6 +132,21 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
 
                 value_stack.push(head);
             }
+            Instr::VarSplit(offset) => {
+                let head = if let LispValue::List(ref mut list) =
+                    *value_stack.get_mut(frame.stack_pointer + offset).unwrap()
+                {
+                    if let Some(elem) = list.pop() {
+                        elem
+                    } else {
+                        return Err(EvaluationError::EmptyList);
+                    }
+                } else {
+                    return Err(EvaluationError::ArgumentTypeMismatch);
+                };
+
+                value_stack.push(head);
+            }
             Instr::VarCar(offset) => {
                 let head = if let LispValue::List(ref list) =
                     *value_stack.get(frame.stack_pointer + offset).unwrap()

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -347,7 +347,7 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
             }
         }
     }
-    
+
     assert!(frame_stack.is_empty());
     assert_eq!(frame.instr_pointer, 0);
     assert_eq!(value_stack.len(), 1);

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -147,6 +147,26 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
 
                 value_stack.push(head);
             }
+            Instr::VarReverseSplit(offset) => {
+                // TODO: see if we can do this more efficiently/ elegantly
+                let tail = {
+                    let reference = value_stack.get_mut(frame.stack_pointer + offset).unwrap();
+                    let mut head = if let LispValue::List(ref mut list) = *reference {
+                        if let Some(elem) = list.pop() {
+                            elem
+                        } else {
+                            return Err(EvaluationError::EmptyList);
+                        }
+                    } else {
+                        return Err(EvaluationError::ArgumentTypeMismatch);
+                    };
+
+                    ::std::mem::swap(&mut head, reference);
+                    head
+                };
+
+                value_stack.push(tail);
+            }
             Instr::VarCar(offset) => {
                 let head = if let LispValue::List(ref list) =
                     *value_stack.get(frame.stack_pointer + offset).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,6 +601,9 @@ enum Instr {
     /// Pushes the car of the variable with given offset to the stack.
     /// This is functionally equivalent to [CloneArgument(offset), Car]
     VarCar(StackOffset),
+    /// Identical to VarCar, except that it replaces the variable at the
+    /// given offset by its Cdr.
+    VarSplit(StackOffset),
     /// Checks whether a variable with given offset is zero and pushes
     /// the result to the stack
     VarCheckZero(StackOffset),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ const PRELUDE: &'static [&'static str] = &[
     "(define map2 (lambda (f l) (cond (null? l) l (cons (f (car (cdr (car l))) (car (car l))) (map2 f (cdr l))))))",
     "(define reverse (lambda (l) (cond (null? l) l (append (list (car l)) (reverse (cdr l))))))",
     "(define !! (lambda (l i) (cond (zero? i) (car l) (!! (cdr l) (sub1 i)))))",
-    "(define foldr (lambda (xs f init) (cond (null? xs) init (foldr (cdr xs) f (f init (car xs))))))",
+    "(define foldr (lambda (f xs init) (cond (null? xs) init (foldr f (cdr xs) (f init (car xs))))))",
 ];
 
 fn exec_command(s: &str, state: &mut State) {


### PR DESCRIPTION
This should make most functions that operate on lists a bit faster. Specifically, functions that use both the `cdr` and `car` of a variable. Performance gains of up to 20%.  