### PR TITLE
Add early return analysis

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -254,8 +254,8 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
                         LispFunc::Custom(f) => {
                             let func_arg_count = f.0.arg_count;
 
-                            // Too many arguments or none at all.
-                            if func_arg_count < arg_count || arg_count == 0 {
+                            // Too many arguments.
+                            if func_arg_count < arg_count {
                                 return Err(EvaluationError::ArgumentCountMismatch);
                             }
                             // Not enough arguments, let's create a lambda that takes

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -374,7 +374,6 @@ pub fn eval(expr: LispExpr, state: &mut State) -> EvaluationResult<LispValue> {
     }
 
     assert!(frame_stack.is_empty());
-    assert_eq!(frame.instr_pointer, 0);
     assert_eq!(value_stack.len(), 1);
     Ok(value_stack.pop().unwrap())
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -23,8 +23,9 @@ fn unitary_list<F: Fn(&mut Vec<LispValue>) -> EvaluationResult<LispValue>>(
 fn compile_top_expr(expr: TopExpr, state: &State) -> EvaluationResult<Vec<Instr>> {
     match expr {
         TopExpr::Define(name, sub_expr) => {
-            let finalized_definition =
-                sub_expr.finalize(&mut FinalizationContext::new(Some(name)))?;
+            let finalized_definition = sub_expr
+                .finalize(&mut FinalizationContext::new(Some(name)))?
+                .0;
 
             let mut instructions = vec![Instr::PopAndSet(name)];
             instructions.extend(compile_finalized_expr(finalized_definition, state)?);


### PR DESCRIPTION
Adds a `Return` instruction. This means we can return at any point in the bytecode and no longer need to jump to the end of the bytecode vector to return. This should've made functions with deeply nested `cond` expressions a bit faster since these would require multiple subsequent jumps to return. In practice, the performance gain is neglible, if there is any at all.